### PR TITLE
WW-3-T-Navbar: Implement Reflexive Navbar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,22 @@
+import Navbar from './components/Navbar.jsx';
+
 function App() {
-  return <>test</>;
+  return (
+    // <>test</>
+    <div>
+      <Navbar />
+      <div id="dummy">
+        <ol>
+          <li id="home">Home</li>
+          <li id="projects">Projects</li>
+          <li id="services">Services</li>
+          <li id="questions">FAQs</li>
+          <li id="team">Our Team</li>
+          <li id="contact">Contact Us</li>
+        </ol>
+      </div>
+    </div>
+  );
 }
 // For Tatsuo's commit
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,14 +6,38 @@ function App() {
     <div>
       <Navbar />
       <div id="dummy">
-        <ol>
-          <li id="home">Home</li>
-          <li id="projects">Projects</li>
-          <li id="services">Services</li>
-          <li id="questions">FAQs</li>
-          <li id="team">Our Team</li>
-          <li id="contact">Contact Us</li>
-        </ol>
+        <ul className="flex flex-col">
+          <li className="flex justify-center align-center h-[700px]" id="home">
+            Home
+          </li>
+          <li
+            className="flex justify-center align-center h-[700px]"
+            id="projects"
+          >
+            Projects
+          </li>
+          <li
+            className="flex justify-center align-center h-[700px]"
+            id="services"
+          >
+            Services
+          </li>
+          <li
+            className="flex justify-center align-center h-[700px]"
+            id="questions"
+          >
+            FAQs
+          </li>
+          <li className="flex justify-center align-center h-[700px]" id="team">
+            Our Team
+          </li>
+          <li
+            className="flex justify-center align-center h-[700px]"
+            id="contact"
+          >
+            Contact Us
+          </li>
+        </ul>
       </div>
     </div>
   );

--- a/src/Components/hooks/useScreenSize.jsx
+++ b/src/Components/hooks/useScreenSize.jsx
@@ -1,0 +1,29 @@
+// useScreenSize.js
+import { useState, useEffect } from 'react';
+
+const useScreenSize = () => {
+  const [screenSize, setScreenSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setScreenSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    // Clean up the event listener when the component unmounts
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return screenSize;
+};
+
+export default useScreenSize;

--- a/src/Components/navbar.jsx
+++ b/src/Components/navbar.jsx
@@ -1,0 +1,20 @@
+// import { useState } from 'react';
+
+// Set states
+// const [isActive, setIsActive] = useState(false);
+
+function Navbar() {
+  return (
+    <nav className="flex justify-evenly">
+      <a href="#home">Home</a>
+      <a href="#projects">Projects</a>
+      <a href="#services">Services</a>
+      <a href="#home">Logo</a>
+      <a href="#questions">FAQs</a>
+      <a href="#team">Our Team</a>
+      <a href="#contact">Contact Us</a>
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/src/Components/navbar.jsx
+++ b/src/Components/navbar.jsx
@@ -5,15 +5,33 @@
 
 function Navbar() {
   return (
-    <nav className="flex justify-evenly">
-      <a href="#home">Home</a>
-      <a href="#projects">Projects</a>
-      <a href="#services">Services</a>
-      <a href="#home">Logo</a>
-      <a href="#questions">FAQs</a>
-      <a href="#team">Our Team</a>
-      <a href="#contact">Contact Us</a>
-    </nav>
+    <div>
+      <nav className="py-5">
+        <ol className="flex w-full justify-evenly text-xl font-bold font-['Inter'] text-navbarWords leading-tight tracking-wide">
+          <li>
+            <a href="#home">Home</a>
+          </li>
+          <li>
+            <a href="#projects">Projects</a>
+          </li>
+          <li>
+            <a href="#services">Services</a>
+          </li>
+          <li>
+            <a href="#home">Logo</a>
+          </li>
+          <li>
+            <a href="#questions">FAQs</a>
+          </li>
+          <li>
+            <a href="#team">Our Team</a>
+          </li>
+          <li>
+            <a href="#contact">Contact Us</a>
+          </li>
+        </ol>
+      </nav>
+    </div>
   );
 }
 

--- a/src/Components/navbar.jsx
+++ b/src/Components/navbar.jsx
@@ -1,36 +1,54 @@
-// import { useState } from 'react';
-
-// Set states
-// const [isActive, setIsActive] = useState(false);
+import { useState, useEffect } from 'react';
+import useScreenSize from './hooks/useScreenSize';
 
 function Navbar() {
+  // Set variables used to evaluate state change
+  // Default to expanded; This means page assumes desktop view
+  const [shouldExpand, setExpand] = useState(true);
+  const screenSize = useScreenSize();
+
+  // useEffect detects when screenSize is less than phone view to make hamburger
+  useEffect(() => {
+    if (screenSize.width < 360) {
+      setExpand(false);
+    } else {
+      setExpand(true);
+    }
+    console.log(screenSize);
+    console.log(shouldExpand);
+  }, [screenSize]);
+
   return (
     <div>
-      <nav className="py-5">
-        <ol className="flex w-full justify-evenly text-xl font-bold font-['Inter'] text-navbarWords leading-tight tracking-wide">
-          <li>
-            <a href="#home">Home</a>
-          </li>
-          <li>
-            <a href="#projects">Projects</a>
-          </li>
-          <li>
-            <a href="#services">Services</a>
-          </li>
-          <li>
-            <a href="#home">Logo</a>
-          </li>
-          <li>
-            <a href="#questions">FAQs</a>
-          </li>
-          <li>
-            <a href="#team">Our Team</a>
-          </li>
-          <li>
-            <a href="#contact">Contact Us</a>
-          </li>
-        </ol>
-      </nav>
+      {shouldExpand ? (
+        <nav className="py-5">
+          <ol className="flex w-full justify-evenly text-xl font-bold font-['Inter'] text-navbarWords leading-tight tracking-wide">
+            <li>
+              <a href="#home">Home</a>
+            </li>
+            <li>
+              <a href="#projects">Projects</a>
+            </li>
+            <li>
+              <a href="#services">Services</a>
+            </li>
+            <li>
+              <a href="#home">Logo</a>
+            </li>
+            <li>
+              <a href="#questions">FAQs</a>
+            </li>
+            <li>
+              <a href="#team">Our Team</a>
+            </li>
+            <li>
+              <a href="#contact">Contact Us</a>
+            </li>
+          </ol>
+        </nav>
+      ) : (
+        <h1> Hello World </h1>
+      )}
     </div>
   );
 }

--- a/src/Components/navbar.jsx
+++ b/src/Components/navbar.jsx
@@ -1,10 +1,13 @@
+import { IoClose } from 'react-icons/io5';
 import { useState, useEffect } from 'react';
 import useScreenSize from './hooks/useScreenSize';
+import hamburger from '../assets/Navbar/Icon.svg';
 
 function Navbar() {
   // Set variables used to evaluate state change
   // Default to expanded; This means page assumes desktop view
   const [shouldExpand, setExpand] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const screenSize = useScreenSize();
 
   // useEffect detects when screenSize is less than phone view to make hamburger
@@ -14,14 +17,12 @@ function Navbar() {
     } else {
       setExpand(true);
     }
-    console.log(screenSize);
-    console.log(shouldExpand);
   }, [screenSize]);
 
   return (
-    <div>
-      {shouldExpand ? (
-        <nav className="py-5">
+    <header className="py-[1.625rem]">
+      <nav className="py-5">
+        {shouldExpand ? (
           <ol className="flex w-full justify-evenly text-xl font-bold font-['Inter'] text-navbarWords leading-tight tracking-wide">
             <li>
               <a href="#home">Home</a>
@@ -45,11 +46,76 @@ function Navbar() {
               <a href="#contact">Contact Us</a>
             </li>
           </ol>
-        </nav>
-      ) : (
-        <h1> Hello World </h1>
+        ) : (
+          <div className="flex flex-row justify-between px-[2rem]">
+            <h2>Weavers Logo</h2>
+            {!isOpen && (
+              <button type="button" onClick={() => setIsOpen(true)}>
+                <img src={hamburger} alt="Hamburger" className="justify-end" />
+              </button>
+            )}
+            {isOpen && (
+              <button type="button" onClick={() => setIsOpen(false)}>
+                <IoClose style={{ fontSize: '2em' }} />
+              </button>
+            )}
+          </div>
+        )}
+      </nav>
+
+      {isOpen && (
+        <ul className="flex flex-col font-normal font-['Inter'] text-lg leading-6">
+          <li className="flex justify-center py-[0.5rem] px-[0.75rem]">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              <a href="#home">Home</a>
+            </button>
+          </li>
+          <li className="flex flex-col justify-center py-[0.5rem]">
+            <hr className="solid " />
+          </li>
+          <li className="flex justify-center py-[0.5rem] px-[0.75rem]">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              <a href="#projects">Projects</a>
+            </button>
+          </li>
+          <li className="flex flex-col justify-center py-[0.5rem]">
+            <hr className="solid " />
+          </li>
+          <li className="flex justify-center py-[0.5rem] px-[0.75rem]">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              <a href="#services">Services</a>
+            </button>
+          </li>
+          <li className="flex flex-col justify-center py-[0.5rem]">
+            <hr className="solid " />
+          </li>
+          <li className="flex justify-center py-[0.5rem] px-[0.75rem]">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              <a href="#questions">FAQs</a>
+            </button>
+          </li>
+          <li className="flex flex-col justify-center py-[0.5rem]">
+            <hr className="solid " />
+          </li>
+          <li className="flex justify-center py-[0.5rem] px-[0.75rem]">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              <a href="#team">Our Team</a>
+            </button>
+          </li>
+          <li className="flex flex-col justify-center py-[0.5rem]">
+            <hr className="solid" />
+          </li>
+          <li className="flex justify-center py-[0.5rem] px-[0.75rem]">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              <a href="#contact">Contact Us</a>
+            </button>
+          </li>
+          <li className="flex flex-col justify-center py-[0.5rem]">
+            <hr className="solid" />
+          </li>
+        </ul>
       )}
-    </div>
+    </header>
   );
 }
 

--- a/src/assets/Navbar/Icon.svg
+++ b/src/assets/Navbar/Icon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Icon">
+<path id="Vector" d="M3 18H21V16H3V18ZM3 13H21V11H3V13ZM3 6V8H21V6H3Z" fill="#1A1C1E"/>
+</g>
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,12 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        desktop: '1440px',
+        mobile: '360px',
+      },
+    },
   },
   plugins: [],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,9 @@ export default {
         desktop: '1440px',
         mobile: '360px',
       },
+      colors: {
+        navbarWords: "#697077"
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
close #3 

Task: Create Navbar Section for both desktop and phone

Solution:
- Implemented a standard navbar using useState and useEffect to manage the expansion mechanic for hamburger.
- Applied about the same spacing and font styles to figma(hopefully its acceptable)

Comment:
- I based some parts of the FVT website for the navbar but ended up not taking everything so hopefully I am not creating any edge cases with this.